### PR TITLE
feat: add endpoint and service method to retrieve all verified psychologists with pagination

### DIFF
--- a/src/modules/psychologist/logic/verificationOfProfessionals/verificationPsychologist.controller.ts
+++ b/src/modules/psychologist/logic/verificationOfProfessionals/verificationPsychologist.controller.ts
@@ -107,6 +107,84 @@ export class VerificationPsychologistController {
     );
   }
 
+  @Get('verified')
+  @Roles([ERole.ADMIN])
+  @ApiOperation({
+    summary: 'Obterner todos los profesionales verificados (SOLO ADMIN)',
+    description: 'Obtener una lista paginada de psicólogos verificados',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Psicólogos verificados recuperados exitosamente',
+    schema: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string', example: 'psychologist-uuid' },
+              name: { type: 'string', example: 'Dr. Ana García' },
+              email: {
+                type: 'string',
+                example: 'ana.garcia@psychologist.com',
+              },
+              license_number: { type: 'string', example: 'PSI-12345' },
+              office_address: {
+                type: 'string',
+                example: 'Consultorio en Av. Callao 1000, Piso 5',
+              },
+              specialities: {
+                type: 'array',
+                items: { type: 'string' },
+                example: ['CLINICAL', 'COUNSELING'],
+              },
+              verified: { type: 'string', example: 'verified' },
+            },
+          },
+        },
+        total: { type: 'number', example: 25 },
+        page: { type: 'number', example: 1 },
+        limit: { type: 'number', example: 10 },
+        totalPages: { type: 'number', example: 3 },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Acceso denegado - Se requiere rol de administrador',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Token inválido o expirado',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'No se encontraron solicitudes de psicólogos verificados',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Número de página (por defecto: 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Elementos por página (por defecto: 5)',
+    example: 10,
+  })
+  getAllVerifiedController(
+    @Query() paginationDto: PaginationDto,
+  ): Promise<PaginatedResponse<ResponseProfessionalDto>> {
+    return this.verificationPsychologistService.getAllVerifiedService(
+      paginationDto,
+    );
+  }
+
   @Put(':id/verify')
   @Roles([ERole.ADMIN])
   @ApiBearerAuth('JWT-auth')

--- a/src/modules/psychologist/logic/verificationOfProfessionals/verificationPsychologist.service.ts
+++ b/src/modules/psychologist/logic/verificationOfProfessionals/verificationPsychologist.service.ts
@@ -47,6 +47,34 @@ export class VerificationPsychologistService {
     };
   }
 
+  async getAllVerifiedService(
+    paginationDto: PaginationDto,
+  ): Promise<PaginatedResponse<ResponseProfessionalDto>> {
+    const queryBuilder =
+      this.psychologistRepository.createQueryBuilder('psychologist');
+    queryBuilder.where('psychologist.verified = :status', {
+      status: EPsychologistStatus.VALIDATED,
+    });
+
+    const paginatedResult = await this.paginationService.paginate(
+      queryBuilder,
+      paginationDto,
+    );
+
+    const transformedItems = plainToInstance(
+      ResponseProfessionalDto,
+      paginatedResult.data,
+      {
+        excludeExtraneousValues: true,
+      },
+    );
+
+    return {
+      ...paginatedResult,
+      data: transformedItems,
+    };
+  }
+
   async findOne(
     id: string,
   ): Promise<{ message: string; data: ResponseProfessionalDto }> {


### PR DESCRIPTION
This pull request introduces a new API endpoint for administrators to retrieve a paginated list of verified psychologists. The main changes include the addition of a controller method to handle the request, comprehensive API documentation, and a corresponding service method to query and return the data in the expected format.

**New endpoint for retrieving verified psychologists:**

* Added a `GET /verified` endpoint in `VerificationPsychologistController` that allows admins to fetch a paginated list of verified psychologists, including full API documentation and query parameters for pagination.

**Service logic for fetching and formatting verified psychologists:**

* Implemented `getAllVerifiedService` in `VerificationPsychologistService` to query only verified psychologists, apply pagination, and transform results into the expected response DTO.