### PR TITLE
feat: remove Google AuthGuard from multiple controllers to streamline authentication

### DIFF
--- a/src/modules/appointments/appointments.controller.ts
+++ b/src/modules/appointments/appointments.controller.ts
@@ -23,10 +23,9 @@ import {
 } from '@nestjs/swagger';
 import { JWTAuthGuard } from '../auth/guards/auth.guard';
 import { AuthenticatedRequest } from '../auth/interfaces/authenticated-request.interface';
-import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('Citas')
-@UseGuards(JWTAuthGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard)
 @ApiBearerAuth('JWT-auth')
 @Controller('appointments')
 export class AppointmentsController {

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -24,11 +24,10 @@ import { JWTAuthGuard } from '../auth/guards/auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/role.decorator';
 import { ERole } from '../../common/enums/role.enum';
-import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('Pagos')
 @Controller('payments')
-@UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard, RolesGuard)
 @ApiBearerAuth('JWT-auth')
 export class PaymentsController {
   constructor(private readonly service: PaymentsService) {}

--- a/src/modules/psychologist/logic/appointmentsOfProfessional/appointmentsOfProfessional.controller.ts
+++ b/src/modules/psychologist/logic/appointmentsOfProfessional/appointmentsOfProfessional.controller.ts
@@ -10,12 +10,11 @@ import { RolesGuard } from '../../../../modules/auth/guards/roles.guard';
 import { AppointmentsOfProfessionalService } from './appointmentsOfProfessional.service';
 import { IAuthRequest } from '../../../../modules/auth/interfaces/auth-request.interface';
 import { Appointment } from 'src/modules/appointments/entities/appointment.entity';
-import { AuthGuard } from '@nestjs/passport';
 
 @Controller('psychologist/appointments')
 @ApiTags('Profesionales')
 @ApiBearerAuth('JWT-auth')
-@UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard, RolesGuard)
 export class AppointmentsOfProfessionalController {
   constructor(
     private readonly appointmentsService: AppointmentsOfProfessionalService,

--- a/src/modules/psychologist/logic/patientsOfProfessional/patientsOfProfessional.controller.ts
+++ b/src/modules/psychologist/logic/patientsOfProfessional/patientsOfProfessional.controller.ts
@@ -12,11 +12,10 @@ import { IAuthRequest } from '../../../auth/interfaces/auth-request.interface';
 import { Roles } from '../../../auth/decorators/role.decorator';
 import { ERole } from '../../../../common/enums/role.enum';
 import { ResponseUserDto } from 'src/modules/users/dto/response-user.dto';
-import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('Profesionales')
 @Controller('psychologist/patients')
-@UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard, RolesGuard)
 @ApiBearerAuth('JWT-auth')
 export class PatientsOfProfessionalController {
   constructor(

--- a/src/modules/psychologist/logic/paymentsOfProfessionals/paymentsOfProfessionals.controller.ts
+++ b/src/modules/psychologist/logic/paymentsOfProfessionals/paymentsOfProfessionals.controller.ts
@@ -12,10 +12,9 @@ import { RolesGuard } from '../../../auth/guards/roles.guard';
 import { IAuthRequest } from '../../../auth/interfaces/auth-request.interface';
 import { PaymentsOfProfessionalsService } from './paymentsOfProfessionals.service';
 import { Payment } from 'src/modules/payments/entities/payment.entity';
-import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('Profesionales')
-@UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard, RolesGuard)
 @ApiBearerAuth('JWT-auth')
 @Controller('psychologist/payments')
 export class PaymentsOfProfessionalsController {

--- a/src/modules/psychologist/logic/profileManagement/profileManagement.controller.ts
+++ b/src/modules/psychologist/logic/profileManagement/profileManagement.controller.ts
@@ -31,11 +31,10 @@ import { UpdatePsychologistDto } from '../../dto/update-psychologist.dto';
 import { ResponseProfessionalDto } from '../../dto/response-professional.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { FileValidationPipe } from 'src/modules/files/pipes/file-validation.pipe';
-import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('Profesionales')
 @Controller('psychologist')
-@UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard, RolesGuard)
 @ApiBearerAuth('JWT-auth')
 export class ProfileManagementController {
   constructor(private profileService: ProfileService) {}

--- a/src/modules/psychologist/logic/reviewsOfProfessionals/reviewsOfProfessionals.controller.ts
+++ b/src/modules/psychologist/logic/reviewsOfProfessionals/reviewsOfProfessionals.controller.ts
@@ -10,11 +10,10 @@ import { RolesGuard } from '../../../auth/guards/roles.guard';
 import { IAuthRequest } from '../../../auth/interfaces/auth-request.interface';
 import { ReviewsProfessionalsService } from './reviewsOfProfessionals.service';
 import { Reviews } from 'src/modules/reviews/entities/reviews.entity';
-import { AuthGuard } from '@nestjs/passport';
 
 @Controller('psychologists/reviews')
 @ApiTags('Profesionales')
-@UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard, RolesGuard)
 @ApiBearerAuth('JWT-auth')
 export class ReviewsOfProfessionalsController {
   constructor(private readonly reviewsService: ReviewsProfessionalsService) {}

--- a/src/modules/psychologist/logic/verificationOfProfessionals/verificationPsychologist.controller.ts
+++ b/src/modules/psychologist/logic/verificationOfProfessionals/verificationPsychologist.controller.ts
@@ -16,12 +16,11 @@ import {
 } from '../../../../common/dto/pagination.dto';
 import { ResponseProfessionalDto } from '../../dto/response-professional.dto';
 import { JWTAuthGuard } from 'src/modules/auth/guards/auth.guard';
-import { AuthGuard } from '@nestjs/passport';
 
 @Controller('psychologist/verification')
 @ApiTags('Profesionales')
 @ApiBearerAuth('JWT-auth')
-@UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard, RolesGuard)
 export class VerificationPsychologistController {
   constructor(
     private readonly verificationPsychologistService: VerificationPsychologistService,

--- a/src/modules/records/records.controller.ts
+++ b/src/modules/records/records.controller.ts
@@ -28,7 +28,6 @@ import {
   ApiConsumes,
   ApiBody,
 } from '@nestjs/swagger';
-import { AuthGuard } from '@nestjs/passport';
 
 @Controller('records')
 @ApiTags('Historiales Médicos')
@@ -42,7 +41,7 @@ import { AuthGuard } from '@nestjs/passport';
 @ApiInternalServerErrorResponse({
   description: 'Error interno del servidor',
 })
-@UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard, RolesGuard)
 export class RecordsController {
   constructor(private readonly recordsService: RecordsService) {}
 

--- a/src/modules/reviews/reviews.controller.ts
+++ b/src/modules/reviews/reviews.controller.ts
@@ -27,11 +27,10 @@ import { reviewResponseDto } from './dto/review-response.dto';
 import { Reviews } from './entities/reviews.entity';
 import { Request } from 'express';
 import { IAuthRequest } from '../auth/interfaces/auth-request.interface';
-import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('Reseñas')
 @Controller('reviews')
-@UseGuards(JWTAuthGuard, AuthGuard('google'))
+@UseGuards(JWTAuthGuard)
 @ApiBearerAuth('JWT-auth')
 export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) {}

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -36,7 +36,6 @@ import { ResponseUserDto } from './dto/response-user.dto';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 import { Payment } from '../payments/entities/payment.entity';
 import { plainToInstance } from 'class-transformer';
-import { AuthGuard } from '@nestjs/passport';
 
 @ApiTags('Usuarios')
 @Controller('users')
@@ -44,7 +43,7 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get()
-  @UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+  @UseGuards(JWTAuthGuard, RolesGuard)
   @Roles([ERole.ADMIN])
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
@@ -327,7 +326,7 @@ export class UsersController {
   }
 
   @Get('patients')
-  @UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+  @UseGuards(JWTAuthGuard, RolesGuard)
   @Roles([ERole.ADMIN])
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
@@ -455,7 +454,7 @@ export class UsersController {
   }
 
   @Get('me')
-  @UseGuards(JWTAuthGuard, AuthGuard('google'))
+  @UseGuards(JWTAuthGuard)
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({ summary: 'Obtener el usuario autenticado' })
   async getMe(@Req() req: IAuthRequest) {
@@ -468,7 +467,7 @@ export class UsersController {
 
   @Get(':id')
   @ResponseType(ResponseUserDto)
-  @UseGuards(JWTAuthGuard, AuthGuard('google') /*, SameUserOrAdminGuard*/)
+  @UseGuards(JWTAuthGuard /*, SameUserOrAdminGuard*/)
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({ summary: 'Get user by ID' })
   @ApiResponse({
@@ -487,7 +486,7 @@ export class UsersController {
   }
 
   @Put(':id')
-  @UseGuards(JWTAuthGuard, SameUserOrAdminGuard, AuthGuard('google'))
+  @UseGuards(JWTAuthGuard, SameUserOrAdminGuard)
   @UseInterceptors(FileInterceptor('profile_picture'))
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({ summary: 'Update user by ID' })
@@ -573,7 +572,7 @@ export class UsersController {
   }
 
   @Delete(':id')
-  @UseGuards(JWTAuthGuard, SameUserOrAdminGuard, AuthGuard('google'))
+  @UseGuards(JWTAuthGuard, SameUserOrAdminGuard)
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({ summary: 'Delete user by ID' })
   @ApiResponse({
@@ -605,7 +604,7 @@ export class UsersController {
   //CODIGO DE PEDRO A PEDIDO DE MAURI
 
   @Get('patient/professionals')
-  @UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+  @UseGuards(JWTAuthGuard, RolesGuard)
   @Roles([ERole.PATIENT])
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
@@ -632,7 +631,7 @@ export class UsersController {
 
   @Get('patient/payments')
   @ApiBearerAuth('JWT-auth')
-  @UseGuards(JWTAuthGuard, RolesGuard, AuthGuard('google'))
+  @UseGuards(JWTAuthGuard, RolesGuard)
   @Roles([ERole.PATIENT])
   @ApiOperation({ summary: 'Obtener los pagos del usuario logueado' })
   @ApiResponse({ status: 200, description: 'Pagos recuperados exitosamente' })


### PR DESCRIPTION
This pull request removes the use of the `AuthGuard('google')` from all controller classes across the codebase, standardizing authentication to use only the custom `JWTAuthGuard` and, where appropriate, `RolesGuard` and other guards. This simplifies the authentication logic and removes dependency on Google OAuth for protected endpoints.

**Authentication Logic Simplification:**

* All controller classes (`appointments.controller.ts`, `payments.controller.ts`, `appointmentsOfProfessional.controller.ts`, `patientsOfProfessional.controller.ts`, `paymentsOfProfessionals.controller.ts`, `profileManagement.controller.ts`, `reviewsOfProfessionals.controller.ts`, `verificationPsychologist.controller.ts`, `records.controller.ts`, `reviews.controller.ts`, `users.controller.ts`) no longer use `AuthGuard('google')` and instead rely solely on `JWTAuthGuard` [[1]](diffhunk://#diff-76f40b807edc383a27f9a8d34d6ee062ed2a534cc2263e81b422045cd7db6ec5L26-R28) [[2]](diffhunk://#diff-9d59aebb5c8de4ea7e5cfb30fa2f92a21605681ebdb98d974155eb95c38ec77fL27-R30) [[3]](diffhunk://#diff-c5e4fe88238a1e1545d232c5ddccec8f4a14369ca406fce17c63493086fdc1c3L13-R17) [[4]](diffhunk://#diff-91bae74d7a3114b9566b6311f622991ec3c5608307356238c8d2ea150f61ce2dL15-R18) [[5]](diffhunk://#diff-9192e104a520ac50824d656ee23f0baf792ba02f3440f78559dbc47751b82534L15-R17) [[6]](diffhunk://#diff-366aeae243c44d049c7aa687c0e8f90fcd13e26b32e32633015520ace750b0aaL34-R37) [[7]](diffhunk://#diff-c97e2cb1380a76d2a4984069e8a96cde5d5636c1c9fd3cf49416255dac2e5bb4L13-R16) [[8]](diffhunk://#diff-c9b253698c7874318e6ed445b262f02ce345af87b6ee2536d75e9e8ca7cfde33L19-R23) [[9]](diffhunk://#diff-dfb495586caa72aa57bea9e265f991e1b7cc25a2ae0572d13653c3c70ecc356eL31) [[10]](diffhunk://#diff-dfb495586caa72aa57bea9e265f991e1b7cc25a2ae0572d13653c3c70ecc356eL45-R44) [[11]](diffhunk://#diff-bf9b382d223037446609382da8e02a7cc9afc47adb9a5c4d9fe541c8e8c7921aL30-R33) [[12]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L39-R46) [[13]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L330-R329) [[14]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L458-R457) [[15]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L471-R470) [[16]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L490-R489) [[17]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L576-R575) [[18]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L608-R607) [[19]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L635-R634).

**Dependency Cleanup:**

* Removed all imports of `AuthGuard` from `@nestjs/passport` in affected controllers, further reducing unnecessary dependencies [[1]](diffhunk://#diff-76f40b807edc383a27f9a8d34d6ee062ed2a534cc2263e81b422045cd7db6ec5L26-R28) [[2]](diffhunk://#diff-9d59aebb5c8de4ea7e5cfb30fa2f92a21605681ebdb98d974155eb95c38ec77fL27-R30) [[3]](diffhunk://#diff-c5e4fe88238a1e1545d232c5ddccec8f4a14369ca406fce17c63493086fdc1c3L13-R17) [[4]](diffhunk://#diff-91bae74d7a3114b9566b6311f622991ec3c5608307356238c8d2ea150f61ce2dL15-R18) [[5]](diffhunk://#diff-9192e104a520ac50824d656ee23f0baf792ba02f3440f78559dbc47751b82534L15-R17) [[6]](diffhunk://#diff-366aeae243c44d049c7aa687c0e8f90fcd13e26b32e32633015520ace750b0aaL34-R37) [[7]](diffhunk://#diff-c97e2cb1380a76d2a4984069e8a96cde5d5636c1c9fd3cf49416255dac2e5bb4L13-R16) [[8]](diffhunk://#diff-c9b253698c7874318e6ed445b262f02ce345af87b6ee2536d75e9e8ca7cfde33L19-R23) [[9]](diffhunk://#diff-dfb495586caa72aa57bea9e265f991e1b7cc25a2ae0572d13653c3c70ecc356eL31) [[10]](diffhunk://#diff-dfb495586caa72aa57bea9e265f991e1b7cc25a2ae0572d13653c3c70ecc356eL45-R44) [[11]](diffhunk://#diff-bf9b382d223037446609382da8e02a7cc9afc47adb9a5c4d9fe541c8e8c7921aL30-R33) [[12]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L39-R46).

**Consistency Across Endpoints:**

* Ensured all protected endpoints use a consistent guard setup, improving maintainability and clarity of access control [[1]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L39-R46) [[2]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L330-R329) [[3]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L458-R457) [[4]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L471-R470) [[5]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L490-R489) [[6]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L576-R575) [[7]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L608-R607) [[8]](diffhunk://#diff-9b7eaf540ae20b215a5b8794f06c779bebdb25084fabce32cc20ea033b055176L635-R634).