### PR TITLE
feat: remove admin role restriction from verified psychologists endpoint

### DIFF
--- a/src/modules/psychologist/logic/verificationOfProfessionals/verificationPsychologist.controller.ts
+++ b/src/modules/psychologist/logic/verificationOfProfessionals/verificationPsychologist.controller.ts
@@ -107,7 +107,6 @@ export class VerificationPsychologistController {
   }
 
   @Get('verified')
-  @Roles([ERole.ADMIN])
   @ApiOperation({
     summary: 'Obterner todos los profesionales verificados (SOLO ADMIN)',
     description: 'Obtener una lista paginada de psicólogos verificados',


### PR DESCRIPTION
This pull request makes a small change to the `VerificationPsychologistController` by removing the `@Roles([ERole.ADMIN])` decorator from the `GET /verified` endpoint. This means that access to the endpoint for fetching verified professionals is no longer restricted to users with the admin role.