### PR TITLE
feat: update psychologist verification status from PENDING to VALIDATED in seeder

### DIFF
--- a/src/modules/seeder/seeder.service.ts
+++ b/src/modules/seeder/seeder.service.ts
@@ -352,7 +352,7 @@ export class SeederService {
           EAvailability.THURSDAY,
           EAvailability.SUNDAY,
         ],
-        verified: EPsychologistStatus.PENDING,
+        verified: EPsychologistStatus.VALIDATED,
         profile_picture:
           'https://res.cloudinary.com/dibnkd72j/image/upload/v1755591733/default-female-psychologist-profile-picture_qyogmy.webp',
       },
@@ -412,7 +412,7 @@ export class SeederService {
           ETherapyApproach.GROUP_THERAPY,
         ],
         availability: [EAvailability.WEDNESDAY, EAvailability.FRIDAY],
-        verified: EPsychologistStatus.PENDING,
+        verified: EPsychologistStatus.VALIDATED,
         profile_picture:
           'https://res.cloudinary.com/dibnkd72j/image/upload/v1755591733/default-female-psychologist-profile-picture_qyogmy.webp',
       },
@@ -471,7 +471,7 @@ export class SeederService {
           ETherapyApproach.ART_THERAPY,
         ],
         availability: [EAvailability.THURSDAY, EAvailability.SUNDAY],
-        verified: EPsychologistStatus.PENDING,
+        verified: EPsychologistStatus.VALIDATED,
         profile_picture:
           'https://res.cloudinary.com/dibnkd72j/image/upload/v1755591733/default-female-psychologist-profile-picture_qyogmy.webp',
       },
@@ -531,7 +531,7 @@ export class SeederService {
           ETherapyApproach.EYE_MOVEMENT_DESENSITIZATION_REPROCESSING,
         ],
         availability: [EAvailability.TUESDAY, EAvailability.SATURDAY],
-        verified: EPsychologistStatus.PENDING,
+        verified: EPsychologistStatus.VALIDATED,
         profile_picture:
           'https://res.cloudinary.com/dibnkd72j/image/upload/v1755591733/default-female-psychologist-profile-picture_qyogmy.webp',
       },


### PR DESCRIPTION
This pull request updates the default verification status for several psychologist seed data entries in the `SeederService`, changing their status from pending to validated. This ensures that seeded psychologists are considered verified in the system by default.

Data seeding updates:

* Changed the `verified` field from `EPsychologistStatus.PENDING` to `EPsychologistStatus.VALIDATED` for four psychologist seed entries in `src/modules/seeder/seeder.service.ts`. [[1]](diffhunk://#diff-c48091c7aa6871d4a577391f67bb87f2cf1beb86c2dd95110af429fef61c1634L355-R355) [[2]](diffhunk://#diff-c48091c7aa6871d4a577391f67bb87f2cf1beb86c2dd95110af429fef61c1634L415-R415) [[3]](diffhunk://#diff-c48091c7aa6871d4a577391f67bb87f2cf1beb86c2dd95110af429fef61c1634L474-R474) [[4]](diffhunk://#diff-c48091c7aa6871d4a577391f67bb87f2cf1beb86c2dd95110af429fef61c1634L534-R534)