### PR TITLE
feat: add validation for user password during sign-in to enforce authentication method

### DIFF
--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -265,6 +265,12 @@ export class AuthService {
       throw new BadRequestException('Email o contraseña inválidos');
     }
 
+    if (!user.password || typeof user.password !== 'string') {
+      throw new BadRequestException(
+        'Este usuario debe iniciar sesión con Google o el método de autenticación correspondiente.',
+      );
+    }
+
     const isPasswordValid = await bcrypt.compare(password, user.password);
 
     if (!isPasswordValid) {


### PR DESCRIPTION
This pull request adds an extra validation step to the authentication logic in the `AuthService`. The main change ensures that users who do not have a password set (such as those registered via Google or other external authentication methods) are prevented from logging in using the standard email/password flow.

Authentication validation improvements:

* Added a check to verify that the `user.password` exists and is a string before attempting password comparison, throwing a specific error if not. This prevents users who registered via Google or other methods without a password from logging in with email/password.