### PR TITLE
feat: integrate Mercado Pago payment preference creation and update user service to handle profile picture logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "cloudinary": "^2.7.0",
     "express-openid-connect": "^2.18.1",
     "lodash": "^4.17.21",
+    "mercadopago": "^2.8.0",
     "passport": "^0.7.0",
     "passport-google-oauth2": "^0.2.0",
     "passport-jwt": "^4.0.1",

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -32,6 +32,35 @@ import { CombinedAuthGuard } from '../auth/guards/combined-auth.guard';
 export class PaymentsController {
   constructor(private readonly service: PaymentsService) {}
 
+  @Post('mercadopago-preference')
+  @Roles([ERole.PATIENT, ERole.ADMIN])
+  @ApiOperation({
+    summary: 'Crear preferencia de pago de Mercado Pago',
+    description:
+      'Generar una preferencia de pago para Mercado Pago y devolver el init_point para redirección.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Preferencia creada exitosamente',
+    schema: {
+      type: 'object',
+      properties: {
+        init_point: {
+          type: 'string',
+          example:
+            'https://www.mercadopago.com.ar/checkout/v1/redirect?pref_id=123',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Error al crear la preferencia de pago',
+  })
+  async createMercadoPagoPreference() {
+    return this.service.createMercadoPagoPreference();
+  }
+
   @Post()
   @Roles([ERole.PATIENT, ERole.ADMIN])
   @ApiOperation({

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -1,9 +1,19 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Payment, PayStatus } from './entities/payment.entity';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { UpdatePaymentDto } from './dto/update-payment.dto';
+import { MercadoPagoConfig, Preference } from 'mercadopago';
+
+// Define interfaces for MercadoPago types
+interface MPPreferenceResult {
+  init_point?: string;
+}
 
 @Injectable()
 export class PaymentsService {
@@ -58,6 +68,67 @@ export class PaymentsService {
 
     if (result.affected === 0) {
       throw new NotFoundException(`Payment with ID ${id} not found`);
+    }
+  }
+
+  async createMercadoPagoPreference(): Promise<{ init_point: string }> {
+    // Safe environment variable access with validation
+    const accessToken = process.env.MP_ACCESS_TOKEN;
+    const frontendUrl = process.env.FRONTEND_URL;
+
+    if (!accessToken) {
+      throw new BadRequestException(
+        'MercadoPago access token is not configured',
+      );
+    }
+
+    if (!frontendUrl) {
+      throw new BadRequestException('Frontend URL is not configured');
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      const client = new MercadoPagoConfig({
+        accessToken,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      const preference = new Preference(client);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      const result: MPPreferenceResult = await preference.create({
+        body: {
+          items: [
+            {
+              id: 'therapy_session',
+              title: 'Pago Unico',
+              quantity: 1,
+              unit_price: 55,
+              currency_id: 'ARS',
+            },
+          ],
+          back_urls: {
+            success: `${frontendUrl}/dashboard/user`,
+            failure: `${frontendUrl}/failure`,
+            pending: `${frontendUrl}/pending`,
+          },
+          auto_return: 'approved',
+        },
+      });
+
+      // Safe access to result with validation
+      if (!result?.init_point) {
+        throw new BadRequestException(
+          'Failed to create MercadoPago preference - invalid response',
+        );
+      }
+
+      return { init_point: result.init_point };
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new BadRequestException('Failed to create MercadoPago preference');
     }
   }
 }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -311,13 +311,28 @@ export class UsersService {
         }
       }
 
+      // ESTE CODIGO COMENTADO ELIMINA LA FOTO DEL PERFIL DEL USUARIO CUANDO  NO AGREGAN UNA PARA REEMPLAZARLA
+
+      // } else if (
+      //   'profile_picture' in userData &&
+      //   (userData.profile_picture === '' ||
+      //     userData.profile_picture === null ||
+      //     userData.profile_picture === undefined)
+      // ) {
+      //   if (user.profile_picture !== DEFAULT_PROFILE_URL) {
+      //     newProfilePictureUrl = DEFAULT_PROFILE_URL;
+      //     profilePictureChanged = true;
+      //   }
+      // }
+      ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
       if (!hasDataChanges && !profilePictureChanged) {
         throw new ConflictException('No se actualizaron campos');
       }
 
       const updatedUser = userRepo.create({
         ...user,
-        ...userData,
+        ...lodash.omit(userData, ['profile_picture']),
         profile_picture: newProfilePictureUrl ?? user.profile_picture,
       });
       await userRepo.save(updatedUser);


### PR DESCRIPTION
This pull request introduces Mercado Pago payment integration into the project. The main changes include adding the `mercadopago` package, implementing a new payment preference endpoint for Mercado Pago, and handling the creation of payment preferences securely with proper error handling. Additionally, there are minor code comments related to user profile picture updates.

**Mercado Pago Integration:**

* Added the `mercadopago` package as a dependency in `package.json` to enable Mercado Pago API integration.
* Implemented the `createMercadoPagoPreference` method in `PaymentsService`, which securely creates a Mercado Pago payment preference, validates environment variables, and handles errors gracefully. [[1]](diffhunk://#diff-0ef0bc1df4a7cf07722f434b7f3edd7c7b0d068d3ec65c59644c8e6f3a444e94L1-R16) [[2]](diffhunk://#diff-0ef0bc1df4a7cf07722f434b7f3edd7c7b0d068d3ec65c59644c8e6f3a444e94R73-R133)
* Added a new endpoint `POST /payments/mercadopago-preference` in `PaymentsController` to allow patients and admins to generate Mercado Pago payment preferences and receive the `init_point` for redirection.

**User Profile Picture Handling:**

* Added commented code in `UsersService` explaining how to reset a user's profile picture to the default if none is provided, but this logic remains inactive for now. Also, updated the user update logic to avoid overwriting the profile picture unless explicitly changed.