### PR TITLE
fix: update redirect URL for user dashboard in Google auth callback

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -105,7 +105,7 @@ export class AuthController {
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
     return res.redirect(
-      'https://psymatch-frontend.onrender.com/dashboard/user',
+      'https://psymatch-frontend-app.onrender.com/dashboard/user',
     );
   }
 }


### PR DESCRIPTION
This pull request updates the redirect URL in the `AuthController` to point to the correct frontend application domain. This ensures users are sent to the intended dashboard after authentication.

* Updated the redirect URL in the `login` method of `AuthController` to use `https://psymatch-frontend-app.onrender.com/dashboard/user` instead of the previous domain.