### PR TITLE
feat(admin): add JWT authentication to admin controller endpoints

### DIFF
--- a/src/modules/admin/logic/admin.module.ts
+++ b/src/modules/admin/logic/admin.module.ts
@@ -1,7 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { JwtModule } from '@nestjs/jwt';
-import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Appointment } from 'src/modules/appointments/entities/appointment.entity';
 import { Payment } from 'src/modules/payments/entities/payment.entity';
 import { Reviews } from 'src/modules/reviews/entities/reviews.entity';

--- a/src/modules/admin/logic/adminEndpoints/admin.controller.ts
+++ b/src/modules/admin/logic/adminEndpoints/admin.controller.ts
@@ -26,6 +26,7 @@ export class AdminController {
   @Get()
   @UseGuards(CombinedAuthGuard, RolesGuard)
   @Roles([ERole.ADMIN])
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary:
       '[Verificacion] Obtener todas las solicitudes de verificación pendientes (SOLO ADMIN)',
@@ -105,6 +106,7 @@ export class AdminController {
   @Put(':id/verify')
   @UseGuards(CombinedAuthGuard, RolesGuard)
   @Roles([ERole.ADMIN])
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: 'Verificar un psicólogo por ID (Solo administradores)',
     description:
@@ -153,6 +155,7 @@ export class AdminController {
   @Put(':id/reject')
   @UseGuards(CombinedAuthGuard, RolesGuard)
   @Roles([ERole.ADMIN])
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: 'Rechazar un psicólogo por ID (Solo administradores)',
     description:
@@ -201,6 +204,7 @@ export class AdminController {
   @Put(':id/promote')
   @UseGuards(CombinedAuthGuard, RolesGuard)
   @Roles([ERole.ADMIN])
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: 'Promover un usuario a un rol superior (Solo administradores)',
     description:
@@ -249,6 +253,7 @@ export class AdminController {
   @Put(':id/ban')
   @UseGuards(CombinedAuthGuard, RolesGuard)
   @Roles([ERole.ADMIN])
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: 'Banear un usuario por ID (Solo administradores)',
     description:
@@ -299,6 +304,7 @@ export class AdminController {
   @Put(':id/unban')
   @UseGuards(CombinedAuthGuard, RolesGuard)
   @Roles([ERole.ADMIN])
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
     summary: 'Desbanear un usuario por ID (Solo administradores)',
     description:


### PR DESCRIPTION
This pull request improves the security documentation of several admin endpoints by explicitly adding JWT authentication requirements to the Swagger API documentation. Additionally, it removes unused imports from the admin module file.

**API documentation improvements:**

* Added `@ApiBearerAuth('JWT-auth')` to all protected admin endpoints in `admin.controller.ts`, ensuring Swagger UI correctly displays JWT authentication requirements for these routes. [[1]](diffhunk://#diff-7a9c2e09f85fd124b95e481cf564a61865965587d381041c30f4c0b4a0b26ca5R29) [[2]](diffhunk://#diff-7a9c2e09f85fd124b95e481cf564a61865965587d381041c30f4c0b4a0b26ca5R109) [[3]](diffhunk://#diff-7a9c2e09f85fd124b95e481cf564a61865965587d381041c30f4c0b4a0b26ca5R158) [[4]](diffhunk://#diff-7a9c2e09f85fd124b95e481cf564a61865965587d381041c30f4c0b4a0b26ca5R207) [[5]](diffhunk://#diff-7a9c2e09f85fd124b95e481cf564a61865965587d381041c30f4c0b4a0b26ca5R256) [[6]](diffhunk://#diff-7a9c2e09f85fd124b95e481cf564a61865965587d381041c30f4c0b4a0b26ca5R307)

**Code cleanup:**

* Removed unused imports (`JwtModule`, `ConfigModule`, `ConfigService`) from `admin.module.ts` to keep the codebase clean and maintainable.