### PR TITLE
fix(emails): update password reset link and template variable

### DIFF
--- a/src/modules/emails/emails.module.ts
+++ b/src/modules/emails/emails.module.ts
@@ -17,6 +17,9 @@ import { envs } from '../../configs/envs.config';
           user: envs.nodemailer.user,
           pass: envs.nodemailer.pass,
         },
+        tls: {
+          rejectUnauthorized: false,
+        },
       },
       defaults: {
         from: envs.nodemailer.from,

--- a/src/modules/emails/emails.service.ts
+++ b/src/modules/emails/emails.service.ts
@@ -80,8 +80,8 @@ export class EmailsService {
       // NECESARIO PARA LA RECUPERACIÓN DE CONTRASEÑA////////////////////
       const resetLink =
         envs.server.environment === 'production'
-          ? `https://psymatch.com/reset-password?token=${resetToken}`
-          : `http://localhost:3000/reset-password?token=${resetToken}`;
+          ? `https://psymatch.com/password/new-password?token=${resetToken}`
+          : `http://localhost:3000/password/new-password?token=${resetToken}`;
       ///////////////////////////////////////////////////////////////////
 
       await this.mailerService.sendMail({

--- a/src/modules/emails/templates/new-password.hbs
+++ b/src/modules/emails/templates/new-password.hbs
@@ -754,7 +754,7 @@
                                         width: auto;
                                       '
                                     ><a
-                                        href='{{restLink}}'
+                                        href='{{resetLink}}'
                                         target='_blank'
                                         class='es-button'
                                         style="


### PR DESCRIPTION
This pull request introduces improvements to the password reset email functionality, including enhanced security settings for email delivery and updates to the password reset link format in both the email service and template.

**Email delivery configuration:**

* Added `tls.rejectUnauthorized: false` to the email transport configuration in `emails.module.ts` to allow connections to mail servers with self-signed or invalid certificates, which can help prevent email delivery issues in certain environments.

**Password reset link updates:**

* Updated the password reset link path in `emails.service.ts` to use `/password/new-password` instead of `/reset-password`, ensuring consistency with frontend routing.
* Fixed a typo in the email template (`new-password.hbs`) by changing the link variable from `restLink` to `resetLink`, ensuring the correct tokenized link is sent to users.