### PR TITLE
feat(appointments): implement soft delete, confirmation, and completi…

### DIFF
--- a/src/modules/appointments/appointments.controller.ts
+++ b/src/modules/appointments/appointments.controller.ts
@@ -10,6 +10,7 @@ import {
   Req,
   Query,
   UseInterceptors,
+  Patch,
 } from '@nestjs/common';
 import { AppointmentsService } from './appointments.service';
 import { CreateAppointmentDto } from './dto/create-appointment.dto';
@@ -89,26 +90,48 @@ export class AppointmentsController {
     return this.appointmentsService.findOneAuthorized(req, id);
   }
 
-  @Put(':id')
-  @ApiOperation({
-    summary: 'Actualizar cita (dueño, psicólogo asignado o admin)',
-  })
-  @ApiParam({ name: 'id', description: 'UUID de la cita' })
-  @ApiBody({ type: UpdateAppointmentDto })
-  update(
-    @Req() req: IAuthRequest,
-    @Param('id') id: string,
-    @Body() dto: UpdateAppointmentDto,
-  ) {
-    return this.appointmentsService.update(req, id, dto);
-  }
-
   @Delete(':id')
   @ApiOperation({
-    summary: 'Eliminar/Cancelar cita (dueño o admin)',
+    summary: 'Deshabilitar cita (soft delete)',
+    description: 'Establece isActive en false en lugar de eliminar la cita completamente. Solo el dueño o admin pueden deshabilitar la cita.',
   })
-  @ApiParam({ name: 'id', description: 'UUID de la cita' })
-  remove(@Req() req: IAuthRequest, @Param('id') id: string) {
-    return this.appointmentsService.remove(req, id);
+  @ApiParam({ 
+    name: 'id', 
+    description: 'UUID de la cita a deshabilitar',
+    type: 'string',
+    format: 'uuid'
+  })
+  disable(@Req() req: IAuthRequest, @Param('id') id: string) {
+    return this.appointmentsService.disable(req, id);
+  }
+
+  @Patch(':id/confirm')
+  @ApiOperation({
+    summary: 'Confirmar cita',
+    description: 'Cambia el estado de la cita de PENDING a CONFIRMED. Solo el psicólogo asignado puede confirmar la cita.',
+  })
+  @ApiParam({ 
+    name: 'id', 
+    description: 'UUID de la cita a confirmar',
+    type: 'string',
+    format: 'uuid'
+  })
+  confirmAppointment(@Req() req: IAuthRequest, @Param('id') id: string) {
+    return this.appointmentsService.confirmAppointment(req, id);
+  }
+
+  @Patch(':id/complete')
+  @ApiOperation({
+    summary: 'Completar cita',
+    description: 'Cambia el estado de la cita de CONFIRMED a COMPLETED. Solo el psicólogo asignado puede completar la cita.',
+  })
+  @ApiParam({ 
+    name: 'id', 
+    description: 'UUID de la cita a completar',
+    type: 'string',
+    format: 'uuid'
+  })
+  completeAppointment(@Req() req: IAuthRequest, @Param('id') id: string) {
+    return this.appointmentsService.completeAppointment(req, id);
   }
 }

--- a/src/modules/appointments/entities/appointment.entity.ts
+++ b/src/modules/appointments/entities/appointment.entity.ts
@@ -9,13 +9,11 @@ export class Appointment {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  // Fecha completa exacta del turno (date + hour)
   @Column({ type: 'timestamptz' })
   date: Date;
 
-  // Guardamos hour aparte para filtros/human-readable
   @Column({ type: 'varchar', length: 5 })
-  hour: string; // "HH:mm"
+  hour: string; 
 
   @Column({ type: 'int', nullable: true, default: 45 })
   duration: number;
@@ -57,4 +55,7 @@ export class Appointment {
 
   @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
   price: number;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
 }

--- a/src/modules/seeder/seeder.module.ts
+++ b/src/modules/seeder/seeder.module.ts
@@ -5,10 +5,11 @@ import { Psychologist } from '../psychologist/entities/psychologist.entity';
 import { Patient } from '../users/entities/patient.entity';
 import { Admin } from '../users/entities/admin.entity';
 import { Reviews } from '../reviews/entities/reviews.entity';
+import { Appointment } from '../appointments/entities/appointment.entity';
 import { envs } from 'src/configs/envs.config';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Patient, Admin, Psychologist, Reviews])],
+  imports: [TypeOrmModule.forFeature([Patient, Admin, Psychologist, Reviews, Appointment])],
   providers: [SeederService],
 })
 export class SeederModule implements OnModuleInit {
@@ -18,6 +19,7 @@ export class SeederModule implements OnModuleInit {
     if (envs.server.environment !== 'production') {
       await this.seederService.seedUsers();
       await this.seederService.seedReviews();
+      await this.seederService.seedAppointments();
     }
   }
 }


### PR DESCRIPTION
…on of appointments; update seeder to include appointments
This pull request introduces significant improvements to the appointments module, focusing on enhanced appointment lifecycle management and improved seeding for development environments. The main changes include replacing the update and delete endpoints with more specific actions (disable, confirm, complete), updating the appointment entity to support soft deletion, and adding seed data for appointments.

**Appointments API enhancements:**

* The `update` and `delete` endpoints in `appointments.controller.ts` have been replaced with three new endpoints: `disable` (soft delete), `confirmAppointment`, and `completeAppointment`, each with clear role-based access and state transitions.
* The corresponding service methods were refactored to implement these new actions, including proper permission checks and state validation for confirming and completing appointments.

**Entity and database changes:**

* Added an `isActive` boolean column to the `Appointment` entity for soft deletion, and clarified the role of the `hour` field. [[1]](diffhunk://#diff-4ccba2efa139429ea6fdcf99eaeb42569d07b1c5bcdda7c75b182a3b3edacba6L12-R16) [[2]](diffhunk://#diff-4ccba2efa139429ea6fdcf99eaeb42569d07b1c5bcdda7c75b182a3b3edacba6R58-R60)

**Seeder improvements:**

* The seeder module now includes the `Appointment` entity and seeds a diverse set of appointments with various statuses (COMPLETED, CONFIRMED, PENDING, CANCELLED), dates, and relationships for development/testing purposes. [[1]](diffhunk://#diff-0e65d1f0928ad1b215d76c9721c21d78e3c73ed6e5ffaa1f3c192e4ada02ab28R8-R12) [[2]](diffhunk://#diff-0e65d1f0928ad1b215d76c9721c21d78e3c73ed6e5ffaa1f3c192e4ada02ab28R22) [[3]](diffhunk://#diff-c48091c7aa6871d4a577391f67bb87f2cf1beb86c2dd95110af429fef61c1634R9-R11) [[4]](diffhunk://#diff-c48091c7aa6871d4a577391f67bb87f2cf1beb86c2dd95110af429fef61c1634R33-R34) [[5]](diffhunk://#diff-c48091c7aa6871d4a577391f67bb87f2cf1beb86c2dd95110af429fef61c1634R692-R948)