### PR TITLE
fix(auth): update redirect URL format in sign-in flow

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -130,8 +130,8 @@ export class AuthController {
 
     const redirectUrl =
       envs.server.environment === 'production'
-        ? `https://psymatch-frontend-app.onrender.com/dashboard/user?token=${jwt}`
-        : `http://localhost:3000/dashboard/user?token=${jwt}`;
+        ? 'https://psymatch-frontend-app.onrender.com/dashboard/user'
+        : 'http://localhost:3000/dashboard/user';
 
     await this.emailsService.sendWelcomeEmail(googleUser.email);
 


### PR DESCRIPTION
This pull request makes a small change to the login redirect behavior in the `AuthController`. The token is no longer appended as a query parameter to the dashboard URL after authentication.

* Updated the redirect URL in `AuthController` to remove the `token` query parameter for both production and development environments (`src/modules/auth/auth.controller.ts`).