### PR TITLE
Dev

### DIFF
--- a/src/modules/emails/templates/new-password.hbs
+++ b/src/modules/emails/templates/new-password.hbs
@@ -970,7 +970,7 @@
                                           color: #4c3b75;
                                           font-size: 14px;
                                         '
-                                      >VISITA NUESTRA APÁGINA WEB</a>
+                                      >VISITA NUESTRA PÁGINA WEB</a>
                                     </p>
                                   </td>
                                 </tr>

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -63,14 +63,33 @@ export class PaymentsController {
     @Query('appointmentId') appointmentId?: string,
     @Query('amount') amount?: number,
   ) {
-    const test = this.service.createMercadoPagoPreference(
+    return this.service.createMercadoPagoPreference(
       userId,
       appointmentId,
       amount,
     );
-    console.log(test);
+  }
 
-    return test;
+  @Post('confirm-payment-success')
+  @Roles([ERole.PATIENT, ERole.ADMIN])
+  @ApiOperation({
+    summary: 'Confirmar pago exitoso y actualizar estado de cita',
+    description: 'Endpoint alternativo para confirmar pago exitoso cuando el webhook no funciona en desarrollo',
+  })
+  async confirmPaymentSuccess(
+    @Body() data: { appointmentId: string; paymentId?: string },
+  ) {
+    // Buscar la cita y actualizar su estado
+    const appointment = await this.service.findAppointmentAndUpdateStatus(data.appointmentId);
+    
+    return {
+      success: true,
+      message: 'Estado de cita actualizado a PENDING_APPROVAL',
+      appointment: {
+        id: appointment.id,
+        status: appointment.status
+      }
+    };
   }
 
   @Post()

--- a/src/modules/payments/webhook.controller.ts
+++ b/src/modules/payments/webhook.controller.ts
@@ -27,4 +27,26 @@ export class WebhookController {
     await this.paymentsService.handleWebhook(webhookData);
     return { status: 'ok' };
   }
+
+  @Post('test-webhook')
+  @ApiOperation({
+    summary: 'Endpoint de prueba para webhook',
+    description: 'Permite probar manualmente el procesamiento de webhooks',
+  })
+  async testWebhook(
+    @Body() testData: { paymentId: string; appointmentId: string },
+  ) {
+    // Simular webhook de MercadoPago
+    const webhookData = {
+      type: 'payment',
+      data: { id: testData.paymentId }
+    };
+    
+    await this.paymentsService.handleWebhook(webhookData);
+    return { 
+      status: 'test-ok',
+      message: 'Test webhook procesado',
+      data: testData
+    };
+  }
 }


### PR DESCRIPTION
This pull request introduces new endpoints and improvements to the payments module to facilitate payment confirmation and webhook testing, especially for local development where MercadoPago cannot reach localhost. It also cleans up unnecessary logging and clarifies development notes. The most important changes are grouped below:

**New endpoints for payment confirmation and webhook testing:**

* Added `confirm-payment-success` endpoint to `PaymentsController` for manually confirming successful payments and updating appointment status when the webhook does not work in development.
* Added `test-webhook` endpoint to `WebhookController` for manually testing webhook processing.

**Service enhancements for appointment status updates:**

* Implemented `findAppointmentAndUpdateStatus` method in `PaymentsService` to allow updating appointment status to `PENDING_APPROVAL` outside of the webhook flow, useful for local development.

**Development notes and code cleanup:**

* Removed unnecessary `console.log` statements from `PaymentsService` and added a note about using ngrok or similar tools to expose the webhook in development environments. [[1]](diffhunk://#diff-0ef0bc1df4a7cf07722f434b7f3edd7c7b0d068d3ec65c59644c8e6f3a444e94L91-L93) [[2]](diffhunk://#diff-0ef0bc1df4a7cf07722f434b7f3edd7c7b0d068d3ec65c59644c8e6f3a444e94R134-R135) [[3]](diffhunk://#diff-0ef0bc1df4a7cf07722f434b7f3edd7c7b0d068d3ec65c59644c8e6f3a444e94L267-L269)

**Minor template correction:**

* Fixed a typo in the `new-password.hbs` email template ("APÁGINA" → "PÁGINA").